### PR TITLE
Fix MuteableRefObject error

### DIFF
--- a/src/hooks/useNuiEvent.ts
+++ b/src/hooks/useNuiEvent.ts
@@ -22,7 +22,7 @@ type NuiHandlerSignature<T> = (data: T) => void;
  **/
 
 export const useNuiEvent = <T = any>(app: string, action: string, handler: (data: T) => void) => {
-  const savedHandler: MutableRefObject<NuiHandlerSignature<T>> = useRef();
+  const savedHandler: MutableRefObject<NuiHandlerSignature<T>> = useRef() as MutableRefObject<NuiHandlerSignature<T>>;
 
   // When handler value changes set mutable ref to handler val
   useEffect(() => {
@@ -33,7 +33,7 @@ export const useNuiEvent = <T = any>(app: string, action: string, handler: (data
     const eventListener = (event: MessageEvent<NuiMessageData<T>>) => {
       const { method: eventAction, app: tgtApp, data } = event.data;
 
-      if (savedHandler.current && savedHandler.current.call) {
+      if (savedHandler.current) {
         if (eventAction === action && tgtApp === app) {
           savedHandler.current(data);
         }


### PR DESCRIPTION

**Pull Request Description**
Latest update causes this error.
MuteableRefObject is not assignable to type 'MutableRefObject<NuiHandlerSignature<T>>' this is *MY* solution for this, BUT it may not be correct as my knowledge with TS is still new.

**Pull Request Checklist**:
* [X] Have you followed the guidelines in our contributing document and Code of Conduct?
* [X] Have you checked to ensure there aren't other open for the same update/change?
* [X] Have you built and tested the `resource` in-game after the relevant change?
